### PR TITLE
Contribute arm64 dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,8 +9,8 @@ RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.k
 RUN echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
 
 # Update local package index and run installs
-RUN sudo apt-get update
-RUN sudo apt-get install cf7-cli sqlite3
+RUN apt-get update
+RUN apt-get install cf7-cli sqlite3
 
 # Install global node modules for SAP CAP and frontend development
 RUN su node -c "npm install -g @ui5/cli @sap/cds-dk yo mbt"

--- a/.devcontainer/arm64/Dockerfile
+++ b/.devcontainer/arm64/Dockerfile
@@ -1,0 +1,30 @@
+# Base build stage
+FROM arm64v8/debian:latest as foundry
+
+# Install necessary dependencies
+RUN apt-get update && \
+    apt-get install -y apt-transport-https ca-certificates gnupg curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install the Cloud Foundry CLI
+RUN curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=v7" | tar -zx && \
+    mv cf7 /usr/local/bin/cf && \
+    chmod +x /usr/local/bin/cf
+
+# Final build stage
+ARG VARIANT="16-buster-slim"
+FROM arm64v8/node:${VARIANT}
+
+COPY --from=foundry /usr/local/bin/cf /usr/local/bin/cf
+
+# Update local package index and run installs
+RUN apt-get update
+
+RUN apt-get install -y sqlite3
+RUN apt-get install -y git 
+
+# Install global node modules for SAP CAP and frontend development
+RUN npm install -g @ui5/cli @sap/cds-dk yo mbt
+
+EXPOSE 8080
+EXPOSE 8081

--- a/.devcontainer/arm64/README.md
+++ b/.devcontainer/arm64/README.md
@@ -1,0 +1,11 @@
+# Info Dockerfile for arm64
+
+## Trivia
+
+Based on the original Dockerfile from this repo, this one will create a base image with which one can natively run a containerized exercise app on an M1/M2 MacBook.
+
+## Issues
+
+Opening the running app via https://localhost:8080 may fail.
+
+To solve this, one needs to add `--accept-remote-connecints` to `ui5 serve`.


### PR DESCRIPTION
As I ran into issues creating a running container from the provided dockerfile prior to the codejam in Timisoara, I set out to adapt the existing one. With the current version one will be able to create an image on an arm64 based machine e.g. MacBook Pro M2 and run the exercise code natively in a docker container. 
The container will have all necessary dependencies installed. The codejam repository can be cloned from github right away. 