### PR TITLE
had a type in the remote connection flag

### DIFF
--- a/.devcontainer/arm64/README.md
+++ b/.devcontainer/arm64/README.md
@@ -8,4 +8,4 @@ Based on the original Dockerfile from this repo, this one will create a base ima
 
 Opening the running app via https://localhost:8080 may fail.
 
-To solve this, one needs to add `--accept-remote-connecints` to `ui5 serve`.
+To solve this, one needs to add `--accept-remote-connections` to `ui5 serve`.


### PR DESCRIPTION
Needed to add this flag again and realised I wrote it wrong in the README. 